### PR TITLE
Inherit book permission from shelve.

### DIFF
--- a/app/Entities/Bookshelf.php
+++ b/app/Entities/Bookshelf.php
@@ -105,7 +105,7 @@ class Bookshelf extends Entity implements HasCoverImage
     }
 
     /**
-     * Add a book to the end of this shelf.
+     * Add a book to the end of this shelf. If shelve inheritance is enabled, copy permissions to book.
      * @param Book $book
      */
     public function appendBook(Book $book)
@@ -116,5 +116,14 @@ class Bookshelf extends Entity implements HasCoverImage
 
         $maxOrder = $this->books()->max('order');
         $this->books()->attach($book->id, ['order' => $maxOrder + 1]);
+
+        if (setting()->get('app-inherit-from-shelve')){
+            $shelfPermissions = $this->permissions()->get(['role_id', 'action'])->toArray();
+            $book->permissions()->delete();
+            $book->restricted = $this->restricted;
+            $book->permissions()->createMany($shelfPermissions);
+            $book->save();
+            $book->rebuildPermissions();
+        }
     }
 }

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -40,6 +40,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
+    'app_inherit_from_shelve' => 'Inherit book permission from shelve',
+    'app_inherit_from_shelve_desc' => 'The permission of the shelve will be copied to the book, when assigning it to a shelve. All other permissions of the book will be overwritten.',
+    'app_inherit_from_shelve_toggle' => 'Enable inheritance',
 
     // Registration Settings
     'reg_settings' => 'Registration',

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -68,6 +68,20 @@
                         </div>
                     </div>
 
+                    <div class="grid half gap-xl">
+                        <div>
+                            <label class="setting-list-label">{{ trans('settings.app_inherit_from_shelve') }}</label>
+                            <p class="small">{!! trans('settings.app_inherit_from_shelve_desc') !!}</p>
+                        </div>
+                        <div>
+                            @include('components.toggle-switch', [
+                                'name' => 'setting-app-inherit-from-shelve',
+                                'value' => setting('app-inherit-from-shelve'),
+                                'label' => trans('settings.app_inherit_from_shelve_toggle'),
+                            ])
+                        </div>
+                    </div>
+
 
                 </div>
 


### PR DESCRIPTION
When ever you assign a book to a shelve and have the "Inherit book permission from shelve" setting enabled, the permissions of the shelve will be copied to the book.